### PR TITLE
Change filenames of frames to match temporally

### DIFF
--- a/nengo_interfaces/airsim.py
+++ b/nengo_interfaces/airsim.py
@@ -404,7 +404,8 @@ class AirSim(nengo.Process):
                         _ = self.get_camera_feedback(
                             camera_name=self.camera_params["camera_name"],
                             save_name=(
-                                f"{self.camera_params['save_name']}/frame_{int(t*1000)}"
+                                f"{self.camera_params['save_name']}"
+                                + f"/frame_{int(t*1000):08d}"
                             ),
                         )
                     else:


### PR DESCRIPTION
Just a quality of life change, so that e.g. frame 1000 won't come before frame 200 in the filesystem.